### PR TITLE
Memcache specific error type

### DIFF
--- a/src/mc/auth.go
+++ b/src/mc/auth.go
@@ -7,7 +7,7 @@ import (
   "strings"
 )
 
-func (cn *Conn) Auth(user, pass string) error {
+func (cn *Conn) Auth(user, pass string) *MCError {
   s, err := cn.authList()
   if err != nil {
     return err
@@ -18,10 +18,10 @@ func (cn *Conn) Auth(user, pass string) error {
     return cn.authPlain(user, pass)
   }
 
-  return fmt.Errorf("mc: unknown auth types %q", s)
+  return &MCError{0xffff, fmt.Sprintf("mc: unknown auth types %q", s)}
 }
 
-func (cn *Conn) authList() (s string, err error) {
+func (cn *Conn) authList() (s string, err *MCError) {
   m := &msg{
     header: header{
       Op: OpAuthList,
@@ -32,7 +32,7 @@ func (cn *Conn) authList() (s string, err error) {
   return m.val, err
 }
 
-func (cn *Conn) authPlain(user, pass string) error {
+func (cn *Conn) authPlain(user, pass string) *MCError {
   m := &msg{
     header: header{
       Op: OpAuthStart,

--- a/src/mc/mc.go
+++ b/src/mc/mc.go
@@ -54,7 +54,7 @@ import (
 //   seconds will actually expire somewhere in the range of (3,4) seconds.
 
 // Retrieve a value from the cache.
-func (cn *Conn) Get(key string) (val string, flags uint32, cas uint64, err error) {
+func (cn *Conn) Get(key string) (val string, flags uint32, cas uint64, err *MCError) {
   // Variants: [R] Get [Q, K, KQ]
   // Request : MUST key; MUST NOT value, extras
   // Response: MAY key, value, extras ([0..3] flags)
@@ -67,7 +67,7 @@ func (cn *Conn) Get(key string) (val string, flags uint32, cas uint64, err error
 // NOTE: GET doesn't actually care about CAS, but we want this internally for
 // testing purposes, to be able to test that a memcache server obeys the proper
 // semantics of ignoring CAS with GETs.
-func (cn *Conn) getCAS(key string, ocas uint64) (val string, flags uint32, cas uint64, err error) {
+func (cn *Conn) getCAS(key string, ocas uint64) (val string, flags uint32, cas uint64, err *MCError) {
   m := &msg{
     header: header{
       Op:  OpGet,
@@ -83,7 +83,7 @@ func (cn *Conn) getCAS(key string, ocas uint64) (val string, flags uint32, cas u
 
 // Get and Touch. Both get the value associated with the key and update its
 // expiration time.
-func (cn *Conn) GAT(key string, exp uint32) (val string, flags uint32, cas uint64, err error) {
+func (cn *Conn) GAT(key string, exp uint32) (val string, flags uint32, cas uint64, err *MCError) {
   // Variants: GAT [Q, K, KQ]
   // Request : MUST key, extras; MUST NOT value
   // Response: MAY key, value, extras ([0..3] flags)
@@ -100,7 +100,7 @@ func (cn *Conn) GAT(key string, exp uint32) (val string, flags uint32, cas uint6
   return m.val, flags, m.CAS, err
 }
 
-func (cn *Conn) Touch(key string, exp uint32) (cas uint64, err error) {
+func (cn *Conn) Touch(key string, exp uint32) (cas uint64, err *MCError) {
   // Variants: Touch
   // Request : MUST key, extras; MUST NOT value
   // Response: MUST NOT key, value, extras
@@ -117,27 +117,27 @@ func (cn *Conn) Touch(key string, exp uint32) (cas uint64, err error) {
 }
 
 // Set a key/value pair in the cache.
-func (cn *Conn) Set(key, val string, flags, exp uint32, ocas uint64) (cas uint64, err error){
+func (cn *Conn) Set(key, val string, flags, exp uint32, ocas uint64) (cas uint64, err *MCError){
   // Variants: [R] Set [Q]
   return cn.setGeneric(OpSet, key, val, ocas, flags, exp)
 }
 
 // Replace an existing key/value in the cache. Fails if key doesn't already
 // exist in cache.
-func (cn *Conn) Replace(key, val string, flags, exp uint32, ocas uint64) (cas uint64, err error){
+func (cn *Conn) Replace(key, val string, flags, exp uint32, ocas uint64) (cas uint64, err *MCError){
   // Variants: Replace [Q]
   return cn.setGeneric(OpReplace, key, val, ocas, flags, exp)
 }
 
 // Add a new key/value to the cache. Fails if the key already exists in the
 // cache.
-func (cn *Conn) Add(key, val string, flags, exp uint32) (cas uint64, err error) {
+func (cn *Conn) Add(key, val string, flags, exp uint32) (cas uint64, err *MCError) {
   // Variants: Add [Q]
   return cn.setGeneric(OpAdd, key, val, 0, flags, exp)
 }
 
 // Set/Add/Replace a key/value pair in the cache.
-func (cn *Conn) setGeneric(op opCode, key, val string, ocas uint64, flags, exp uint32) (cas uint64, err error) {
+func (cn *Conn) setGeneric(op opCode, key, val string, ocas uint64, flags, exp uint32) (cas uint64, err *MCError) {
   // Request : MUST key, value, extras ([0..3] flags, [4..7] expiration)
   // Response: MUST NOT key, value, extras
   // CAS: If a CAS is specified (non-zero), all sets only succeed if the key
@@ -158,18 +158,18 @@ func (cn *Conn) setGeneric(op opCode, key, val string, ocas uint64, flags, exp u
 
 // Increment a value in the cache. The value must be an unsigned 64bit integer
 // stored as an ASCII string. It will wrap when incremented outside the range.
-func (cn *Conn) Incr(key string, delta, init uint64, exp uint32, ocas uint64) (n, cas uint64, err error) {
+func (cn *Conn) Incr(key string, delta, init uint64, exp uint32, ocas uint64) (n, cas uint64, err *MCError) {
   return cn.incrdecr(OpIncrement, key, delta, init, exp, ocas)
 }
 
 // Decrement a value in the cache. The value must be an unsigned 64bit integer
 // stored as an ASCII string. It can't be decremented below 0.
-func (cn *Conn) Decr(key string, delta, init uint64, exp uint32, ocas uint64) (n, cas uint64, err error) {
+func (cn *Conn) Decr(key string, delta, init uint64, exp uint32, ocas uint64) (n, cas uint64, err *MCError) {
   return cn.incrdecr(OpDecrement, key, delta, init, exp, ocas)
 }
 
 // Incr/Decr a key/value pair in the cache.
-func (cn *Conn) incrdecr(op opCode, key string, delta, init uint64, exp uint32, ocas uint64) (n, cas uint64, err error) {
+func (cn *Conn) incrdecr(op opCode, key string, delta, init uint64, exp uint32, ocas uint64) (n, cas uint64, err *MCError) {
   // Variants: [R] Incr [Q], [R] Decr [Q]
   // Request : MUST key, extras; MUST NOT value
   //   Extras: [ 0.. 7] Amount to add/sub
@@ -210,7 +210,7 @@ func readInt(b string) uint64 {
 
 // Append the value to the existing value for the key specified. An error is
 // thrown if the key doesn't exist.
-func (cn *Conn) Append(key, val string, ocas uint64) (cas uint64, err error) {
+func (cn *Conn) Append(key, val string, ocas uint64) (cas uint64, err *MCError) {
   // Variants: [R] Append [Q]
   // Request : MUST key, value; MUST NOT extras
   // Response: MUST NOT key, value, extras
@@ -229,7 +229,7 @@ func (cn *Conn) Append(key, val string, ocas uint64) (cas uint64, err error) {
 
 // Prepend the value to the existing value for the key specified. An error is
 // thrown if the key doesn't exist.
-func (cn *Conn) Prepend(key, val string, ocas uint64) (cas uint64, err error) {
+func (cn *Conn) Prepend(key, val string, ocas uint64) (cas uint64, err *MCError) {
   // Variants: [R] Append [Q]
   // Request : MUST key, value; MUST NOT extras
   // Response: MUST NOT key, value, extras
@@ -272,7 +272,7 @@ func (cn *Conn) DelCAS(key string, cas uint64) error {
 // free memory on a memcache server (doing so compromises the O(1) nature of
 // memcache). Instead nearly all servers do lazy expiration, where they don't
 // free memory but won't return any keys to you that have expired.
-func (cn *Conn) Flush(when uint32) (err error) {
+func (cn *Conn) Flush(when uint32) (err *MCError) {
   // Variants: Flush [Q]
   // Request : MUST NOT key, value; MAY extras ([0..3] expiration)
   // Response: MUST NOT key, value, extras
@@ -292,7 +292,7 @@ func (cn *Conn) Flush(when uint32) (err error) {
 
 // Send a No-Op message to the memcache server. This can be used as a heartbeat
 // for the server to check it's functioning fine still.
-func (cn *Conn) NoOp() (err error) {
+func (cn *Conn) NoOp() (err *MCError) {
   // Variants: NoOp
   // Request : MUST NOT key, value, extras
   // Response: MUST NOT key, value, extras
@@ -306,7 +306,7 @@ func (cn *Conn) NoOp() (err error) {
 }
 
 // Get the version of the memcached server connected to.
-func (cn *Conn) Version() (ver string, err error) {
+func (cn *Conn) Version() (ver string, err *MCError) {
   // Variants: Version
   // Request : MUST NOT key, value, extras
   // Response: MUST NOT key, extras; MUST value
@@ -323,7 +323,7 @@ func (cn *Conn) Version() (ver string, err error) {
 }
 
 // Close connection with memcache server (nicely).
-func (cn *Conn) Quit() (err error) {
+func (cn *Conn) Quit() (err *MCError) {
   // Variants: Quit [Q]
   // Request : MUST NOT key, value, extras
   // Response: MUST NOT key, value, extras
@@ -339,7 +339,7 @@ func (cn *Conn) Quit() (err error) {
 }
 
 // Stats returns some statistics about the memcached server.
-func (cn *Conn) Stats() (stats map[string]string, err error) {
+func (cn *Conn) Stats() (stats map[string]string, err *MCError) {
   // Variants: Stats
   // Request : MAY HAVE key, MUST NOT value, extra
   // Response: Serries of responses that MUST HAVE key, value; followed by one

--- a/src/mc/protocol.go
+++ b/src/mc/protocol.go
@@ -2,41 +2,60 @@ package mc
 
 // Deal with the protocol specification of Memcached.
 
-import (
-  "errors"
-)
+type MCError struct {
+  Status uint16
+  Message string
+}
+
+func NewMCError(status uint16) *MCError {
+  switch status {
+    case 1:
+      return &MCError{Status:status, Message: ErrNotFound}
+    case 2:
+      return &MCError{Status:status, Message: ErrKeyExists}
+    case 3:
+      return &MCError{Status:status, Message: ErrValueTooLarge}
+    case 4:
+      return &MCError{Status:status, Message: ErrInvalidArgs}
+    case 5:
+      return &MCError{Status:status, Message: ErrValueNotStored}
+    case 6:
+      return &MCError{Status:status, Message: ErrNonNumeric}
+    case 0x20:
+      return &MCError{Status:status, Message: ErrAuthRequired}
+
+    // we only support PLAIN auth, no mechanism that would make use of auth
+    // continue, so make it an error for now for completeness.
+    case 0x21:
+      return &MCError{Status:status, Message: ErrAuthContinue}
+    case 0x81:
+      return &MCError{Status:status, Message: ErrUnknownCommand}
+    case 0x82:
+      return &MCError{Status:status, Message: ErrOutOfMemory}
+    default:
+      return nil
+  }
+}
+
+func (err MCError) Error() string {
+  return err.Message
+}
 
 // Errors
 var (
-  ErrNotFound       = errors.New("mc: not found")
-  ErrKeyExists      = errors.New("mc: key exists")
-  ErrValueTooLarge  = errors.New("mc: value to large")
-  ErrInvalidArgs    = errors.New("mc: invalid arguments")
-  ErrValueNotStored = errors.New("mc: value not stored")
-  ErrNonNumeric     = errors.New("mc: incr/decr called on non-numeric value")
-  ErrAuthRequired   = errors.New("mc: authentication required")
-  ErrAuthContinue   = errors.New("mc: authentication continue (unsupported)")
-  ErrUnknownCommand = errors.New("mc: unknown command")
-  ErrOutOfMemory    = errors.New("mc: out of memory")
+  ErrNotFound       = "mc: not found"
+  ErrKeyExists      = "mc: key exists"
+  ErrValueTooLarge  = "mc: value to large"
+  ErrInvalidArgs    = "mc: invalid arguments"
+  ErrValueNotStored = "mc: value not stored"
+  ErrNonNumeric     = "mc: incr/decr called on non-numeric value"
+  ErrAuthRequired   = "mc: authentication required"
+  ErrAuthContinue   = "mc: authentication continue (unsupported)"
+  ErrUnknownCommand = "mc: unknown command"
+  ErrOutOfMemory    = "mc: out of memory"
   // for unknown errors from client...
-  ErrUnknownError   = errors.New("mc: unknown error from server")
+  ErrUnknownError   = "mc: unknown error from server"
 )
-
-var errMap = map[uint16]error{
-  0:    nil,
-  1:    ErrNotFound,
-  2:    ErrKeyExists,
-  3:    ErrValueTooLarge,
-  4:    ErrInvalidArgs,
-  5:    ErrValueNotStored,
-  6:    ErrNonNumeric,
-  0x20: ErrAuthRequired,
-  // we only support PLAIN auth, no mechanism that would make use of auth
-  // continue, so make it an error for now for completeness.
-  0x21: ErrAuthContinue,
-  0x81: ErrUnknownCommand,
-  0x82: ErrOutOfMemory,
-}
 
 type opCode uint8
 

--- a/src/mc/server.go
+++ b/src/mc/server.go
@@ -42,7 +42,7 @@ func (cn *Conn) Close() error {
 // sendRecv sends and receives a complete memcache request/response exchange.
 //
 // LOCK INVARIANT: protected by the Conn.l lock.
-func (cn *Conn) sendRecv(m *msg) (err error) {
+func (cn *Conn) sendRecv(m *msg) (err *MCError) {
   cn.l.Lock()
   defer cn.l.Unlock()
 
@@ -62,7 +62,7 @@ func (cn *Conn) sendRecv(m *msg) (err error) {
 // send sends a request to the memcache server.
 //
 // LOCK INVARIANT: Unprotected.
-func (cn *Conn) send(m *msg) (err error) {
+func (cn *Conn) send(m *msg) *MCError {
   m.Magic = 0x80
   m.ExtraLen = sizeOfExtras(m.iextras)
   m.KeyLen = uint16(len(m.key))
@@ -71,55 +71,58 @@ func (cn *Conn) send(m *msg) (err error) {
   cn.opq += 1
 
   // Request
-  err = binary.Write(cn.buf, binary.BigEndian, m.header)
+  err := binary.Write(cn.buf, binary.BigEndian, m.header)
   if err != nil {
-    return
+    return &MCError{0xffff, err.Error()}
   }
 
   for _, e := range m.iextras {
     err = binary.Write(cn.buf, binary.BigEndian, e)
     if err != nil {
-      return
+      return &MCError{0xffff, err.Error()}
     }
   }
 
   _, err = io.WriteString(cn.buf, m.key)
   if err != nil {
-    return
+    return &MCError{0xffff, err.Error()}
   }
 
   _, err = io.WriteString(cn.buf, m.val)
   if err != nil {
-    return
+    return &MCError{0xffff, err.Error()}
   }
 
   _, err = cn.buf.WriteTo(cn.rwc)
-  return
+  if err != nil {
+    return &MCError{0xffff, err.Error()}
+  }
+  return nil
 }
 
 // recv receives a memcached response. It takes a msg into which to store the
 // response.
 //
 // LOCK INVARIANT: Unprotected.
-func (cn *Conn) recv(m *msg) (err error) {
-  err = binary.Read(cn.rwc, binary.BigEndian, &m.header)
+func (cn *Conn) recv(m *msg) *MCError {
+  err := binary.Read(cn.rwc, binary.BigEndian, &m.header)
   if err != nil {
-    return
+    return &MCError{0xffff, err.Error()}
   }
 
   bd := make([]byte, m.BodyLen)
   _, err = io.ReadFull(cn.rwc, bd)
   if err != nil {
-    return
+    return &MCError{0xffff, err.Error()}
   }
 
   buf := bytes.NewBuffer(bd)
 
   if m.ResvOrStatus == 0 && m.ExtraLen > 0 {
     for _, e := range m.oextras {
-      err = binary.Read(buf, binary.BigEndian, e)
+      err := binary.Read(buf, binary.BigEndian, e)
       if err != nil {
-        return
+        return &MCError{0xffff, err.Error()}
       }
     }
   }
@@ -132,12 +135,8 @@ func (cn *Conn) recv(m *msg) (err error) {
 }
 
 // checkError checks if the received response is an error.
-func checkError(m *msg) error {
-  err, ok := errMap[m.ResvOrStatus]
-  if !ok {
-    return ErrUnknownError
-  }
-  return err
+func checkError(m *msg) *MCError {
+  return NewMCError(m.ResvOrStatus)
 }
 
 // sizeOfExtras returns the size of the extras field for the memcache request.


### PR DESCRIPTION
Allows clients to differentiate between error types by storing the
error status in the type. Uses 0xffff as a default for errors that do
not correspond to memcache protocol error statuses.