### PR TITLE
Export mcStats

### DIFF
--- a/client.go
+++ b/client.go
@@ -441,7 +441,7 @@ func (c *Client) Quit() {
 // StatsWithKey returns some statistics about the memcached server. It supports
 // sending across a key to the server to select which statistics should be
 // returned.
-func (c *Client) StatsWithKey(key string) (map[string]mcStats, error) {
+func (c *Client) StatsWithKey(key string) (map[string]McStats, error) {
 	// Variants: Stats
 	// Request : MAY HAVE key, MUST NOT value, extra
 	// Response: Serries of responses that MUST HAVE key, value; followed by one
@@ -453,7 +453,7 @@ func (c *Client) StatsWithKey(key string) (map[string]mcStats, error) {
 		key: key,
 	}
 
-	allStats := make(map[string]mcStats)
+	allStats := make(map[string]McStats)
 	for _, s := range c.servers {
 		if s.isAlive {
 			stats, err := s.performStats(m)
@@ -468,7 +468,7 @@ func (c *Client) StatsWithKey(key string) (map[string]mcStats, error) {
 }
 
 // Stats returns some statistics about the memcached server.
-func (c *Client) Stats() (stats map[string]mcStats, err error) {
+func (c *Client) Stats() (stats map[string]McStats, err error) {
 	return c.StatsWithKey("")
 }
 

--- a/mock_conn.go
+++ b/mock_conn.go
@@ -48,7 +48,7 @@ func (mc *mockConn) perform(m *msg) error {
 	return &Error{StatusNetworkError, "Mock network error", nil}
 }
 
-func (mc *mockConn) performStats(m *msg) (mcStats, error) {
+func (mc *mockConn) performStats(m *msg) (McStats, error) {
 	return nil, nil
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -176,4 +176,4 @@ type msg struct {
 }
 
 // Memcache stats
-type mcStats map[string]string
+type McStats map[string]string

--- a/server.go
+++ b/server.go
@@ -88,7 +88,7 @@ func (s *server) perform(m *msg) error {
 	// return err
 }
 
-func (s *server) performStats(m *msg) (mcStats, error) {
+func (s *server) performStats(m *msg) (McStats, error) {
 	timeout := time.After(s.config.ConnectionTimeout)
 	select {
 	case c := <-s.pool:

--- a/server_conn.go
+++ b/server_conn.go
@@ -14,7 +14,7 @@ import (
 
 type mcConn interface {
 	perform(m *msg) error
-	performStats(m *msg) (mcStats, error)
+	performStats(m *msg) (McStats, error)
 	quit(m *msg)
 	backup(m *msg)
 	restore(m *msg)
@@ -56,7 +56,7 @@ func (sc *serverConn) perform(m *msg) error {
 	return sc.sendRecv(m)
 }
 
-func (sc *serverConn) performStats(m *msg) (mcStats, error) {
+func (sc *serverConn) performStats(m *msg) (McStats, error) {
 	// lazy connection
 	if sc.conn == nil {
 		err := sc.connect()
@@ -160,7 +160,7 @@ func (sc *serverConn) sendRecv(m *msg) error {
 }
 
 // sendRecvStats
-func (sc *serverConn) sendRecvStats(m *msg) (stats mcStats, err error) {
+func (sc *serverConn) sendRecvStats(m *msg) (stats McStats, err error) {
 	err = sc.send(m)
 	if err != nil {
 		sc.resetConn(err)


### PR DESCRIPTION
mcStats is currently non-exported, but is returned by the public
function StatsWithKey. Because of this, it is impossible to mock
out that portion of the Client. This pull request changes McStats
to public so the Client can be mocked.

An alternative to this PR would be to return `map[string]string` instead of `mcStats`