### PR TITLE
Fix issue 12. Broadcast functions break in multinode setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,4 @@ install:
 script:
   - make
   - make test-full
+  - make test-multinode

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,14 @@ test-full: build
 	cd $(CURDIR); cat test.pids | xargs kill; rm test.pids
 	@exit ${ST}
 
+test-multinode: build
+	@memcached -p 11289 & echo $$! > test.pids
+	@memcached -p 11290 & echo $$! >> test.pids
+	@memcached -p 11291 & echo $$! >> test.pids
+	@GOPATH=$(CURDIR) GO15VENDOREXPERIMENT=1 $(GO) test -run '^TestMultiNode' -v -tags=multinode; ST=$?; \
+	cat test.pids | xargs kill; rm test.pids
+	@exit ${ST}
+
 bench: build
 	@memcached -p 11289 & echo $$! > test.pids
 	@GOPATH=$(CURDIR) $(GO) test -run "notests" -bench ".*"; ST=$?; \

--- a/client.go
+++ b/client.go
@@ -370,7 +370,8 @@ func (c *Client) Flush(when uint32) (err error) {
 
 	for _, s := range c.servers {
 		if s.isAlive {
-			err = s.perform(m)
+			var ms msg = *m
+			err = s.perform(&ms)
 		}
 	}
 	return err // retrns err from last perform but maybe should handle differently
@@ -390,7 +391,8 @@ func (c *Client) NoOp() (err error) {
 
 	for _, s := range c.servers {
 		if s.isAlive {
-			err = s.perform(m)
+			var ms msg = *m
+			err = s.perform(&ms)
 		}
 	}
 	return err // retrns err from last perform but maybe should handle differently
@@ -412,9 +414,10 @@ func (c *Client) Version() (vers map[string]string, err error) {
 	vers = make(map[string]string)
 	for _, s := range c.servers {
 		if s.isAlive {
-			err = s.perform(m)
+			var ms msg = *m
+			err = s.perform(&ms)
 			if err == nil {
-				vers[s.address] = m.val
+				vers[s.address] = ms.val
 			}
 		}
 	}
@@ -434,7 +437,8 @@ func (c *Client) Quit() {
 	}
 
 	for _, s := range c.servers {
-		s.quit(m)
+		var ms msg = *m
+		s.quit(&ms)
 	}
 }
 

--- a/multi_node_test.go
+++ b/multi_node_test.go
@@ -1,0 +1,21 @@
+// +build multinode
+
+package mc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+)
+
+func TestMultiNodeVersion(t *testing.T) {
+	c := testInitMultiNode(t, "localhost:11289 localhost:11290 localhost:11291", "", "")
+	vers, err := c.Version()
+	assertEqualf(t, nil, err, "unexpected error: %v", err)
+	for k, v := range vers {
+		fmt.Printf("    host: %s  version: %s\n", k, v)
+		good, errRegex := regexp.MatchString("[0-9]+\\.[0-9]+\\.[0-9]+", v)
+		assertEqualf(t, nil, errRegex, "unexpected error: %v", errRegex)
+		assertEqualf(t, good, true, "version of unexcpected form: %s", v)
+	}
+}

--- a/multi_node_test.go
+++ b/multi_node_test.go
@@ -18,4 +18,19 @@ func TestMultiNodeVersion(t *testing.T) {
 		assertEqualf(t, nil, errRegex, "unexpected error: %v", errRegex)
 		assertEqualf(t, good, true, "version of unexcpected form: %s", v)
 	}
+	c.Quit()
+}
+
+func TestMultiNodeNoOp(t *testing.T) {
+	c := testInitMultiNode(t, "localhost:11289 localhost:11290 localhost:11291", "", "")
+	err := c.NoOp()
+	assertEqualf(t, nil, err, "unexpected error: %v", err)
+	c.Quit()
+}
+
+func TestMultiNodeFlush(t *testing.T) {
+	c := testInitMultiNode(t, "localhost:11289 localhost:11290 localhost:11291", "", "")
+	err := c.Flush(0)
+	assertEqualf(t, nil, err, "unexpected error: %v", err)
+	c.Quit()
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -13,6 +13,14 @@ func testInit(t *testing.T) *Client {
 	return c
 }
 
+// start connection
+func testInitMultiNode(t *testing.T, servers, username, password string) *Client {
+	c := NewMC(servers, user, pass)
+	err := c.Flush(0)
+	assertEqualf(t, nil, err, "unexpected error during initial flush: %v", err)
+	return c
+}
+
 // TODO: asserts gives just the location of FailNow, more of a stack trace would be nice
 
 func assertEqualf(t *testing.T, exp, got interface{}, format string, args ...interface{}) {


### PR DESCRIPTION
Fix issue https://github.com/memcachier/mc/issues/12

In "broadcast" type of messages (like `Version()`) use a new, local, message object for each send.



P.S  Unit test in travis are broken for go >= 1.11 (false positive, they never run)
There is an easy way to fix that but it would require drop unittest run for go <= 1.10