### PR TITLE
Update Readme.md and fixed Decompress and compress method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,24 +33,24 @@ func main() {
   // Error handling omitted for demo
 
   // Only PLAIN SASL auth supported right now
-	c := mc.NewMC("localhost:11211", "username", "password")
-	defer c.Quit()
+  c := mc.NewMC("localhost:11211", "username", "password")
+  defer c.Quit()
 
-	exp := 3600 // 2 hours
-	cas, err = c.Set("foo", "bar", flags, exp, cas)
-	if err != nil {
-		...
-	}
+  exp := 3600 // 2 hours
+  cas, err = c.Set("foo", "bar", flags, exp, cas)
+  if err != nil {
+  	...
+  }
 
-	val, flags, cas, err = c.Get("foo")
-	if err != nil {
-		...
-	}
+  val, flags, cas, err = c.Get("foo")
+  if err != nil {
+  	...
+  }
 
-	err = c.Del("foo")
-	if err != nil {
-		...
-	}
+  err = c.Del("foo")
+  if err != nil {
+  	...
+  }
 }
 ```
 
@@ -71,7 +71,7 @@ func main() {
   config := mc.DefaultConfig()
 
   // You have to set the functions to compress and descompress
-  // At this example we are using zlib
+  // At this example we are using zlib.
 
   config.Compression.Decompress = func(value string) (string, error) {
   	var compressedValue bytes.Buffer
@@ -141,7 +141,7 @@ func main() {
   config := mc.DefaultConfig()
 
   // You have to set the functions to compress and descompress
-  // At this example we are using gzip
+  // At this example we are using gzip.
 
   config.Compression.Decompress = func(value string) (string, error) {
   	var compressedValue bytes.Buffer

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ import "github.com/memcachier/mc/v3"
 // import "github.com/memcachier/mc"
 
 func main() {
-	// Error handling omitted for demo
+  // Error handling omitted for demo
 
-	// Only PLAIN SASL auth supported right now
+  // Only PLAIN SASL auth supported right now
 	c := mc.NewMC("localhost:11211", "username", "password")
 	defer c.Quit()
 
@@ -54,7 +54,7 @@ func main() {
 }
 ```
 
-## Using Compression
+## Using zlib Compression
 
 ```go
 import (
@@ -65,62 +65,132 @@ import (
 // import "github.com/memcachier/mc"
 
 func main() {
-	// Error handling omitted for demo
+  // Error handling omitted for demo
 
-	// Only PLAIN SASL auth supported right now
+  // Only PLAIN SASL auth supported right now
   config := mc.DefaultConfig()
 
-  // You have to set the functions to deflate and unzip
-	// At this example we are using zlib
+  // You have to set the functions to compress and descompress
+  // At this example we are using zlib
 
-  config.Compression.decompress = func(value string) (string, error) {
-		var compressedValue bytes.Buffer
-		zw, err := zlib.NewWriterLevel(&compressedValue, -1)
-		if err != nil {
-			return value, err
-		}
-		if _, err = zw.Write([]byte(value)); err != nil {
-			return value, err
-		}
-		zw.Close()
-		return compressedValue.String(), nil
-	}
+  config.Compression.Decompress = func(value string) (string, error) {
+  	var compressedValue bytes.Buffer
+  	zw, err := zlib.NewWriterLevel(&compressedValue, -1)
+  	if err != nil {
+  		return value, err
+  	}
+  	if _, err = zw.Write([]byte(value)); err != nil {
+  		return value, err
+  	}
+  	zw.Close()
+  	return compressedValue.String(), nil
+  }
 
-	config.Compression.compress = func(value string) (string, error) {
-		if value == "" {
-			return value, nil
-		}
-		zr, err := zlib.NewReader(strings.NewReader(value))
-		if err != nil {
-			return value, nil // Does not return error, the value could be not compressed
-		}
-		defer zr.Close()
-		var unCompressedValue bytes.Buffer
-		_, err = io.Copy(&unCompressedValue, zr)
-		if err != nil {
-			return value, nil
-		}
-		return unCompressedValue.String(), nil
-	}
+  config.Compression.Compress = func(value string) (string, error) {
+  	if value == "" {
+  		return value, nil
+  	}
+  	zr, err := zlib.NewReader(strings.NewReader(value))
+  	if err != nil {
+  		return value, nil // Does not return error, the value could be not compressed
+  	}
+  	defer zr.Close()
+  	var unCompressedValue bytes.Buffer
+  	_, err = io.Copy(&unCompressedValue, zr)
+  	if err != nil {
+  		return value, nil
+  	}
+  	return unCompressedValue.String(), nil
+  }
 
-	c := mc.NewMCwithConfig("localhost:11211", "username", "password", config)
-	defer c.Quit()
+  c := mc.NewMCwithConfig("localhost:11211", "username", "password", config)
+  defer c.Quit()
 
-	exp := 3600 // 2 hours
-	cas, err = c.Set("foo", "bar", flags, exp, cas)
-	if err != nil {
-		...
-	}
+  exp := 3600 // 2 hours
+  cas, err = c.Set("foo", "bar", flags, exp, cas)
+  if err != nil {
+  	...
+  }
 
-	val, flags, cas, err = c.Get("foo")
-	if err != nil {
-		...
-	}
+  val, flags, cas, err = c.Get("foo")
+  if err != nil {
+  	...
+  }
 
-	err = c.Del("foo")
-	if err != nil {
-		...
-	}
+  err = c.Del("foo")
+  if err != nil {
+  	...
+  }
+}
+```
+
+## Using gzip Compression
+
+```go
+import (
+  "github.com/memcachier/mc/v3"
+  "compress/gzip"
+)
+// Legacy GOPATH mode:
+// import "github.com/memcachier/mc"
+
+func main() {
+  // Error handling omitted for demo
+
+  // Only PLAIN SASL auth supported right now
+  config := mc.DefaultConfig()
+
+  // You have to set the functions to compress and descompress
+  // At this example we are using gzip
+
+  config.Compression.Decompress = func(value string) (string, error) {
+  	var compressedValue bytes.Buffer
+  	zw, err := gzip.NewWriterLevel(&compressedValue, -1)
+  	if err != nil {
+  		return value, err
+  	}
+  	if _, err = zw.Write([]byte(value)); err != nil {
+  		return value, err
+  	}
+  	zw.Close()
+  	return compressedValue.String(), nil
+  }
+
+  config.Compression.Compress = func(value string) (string, error) {
+  	if value == "" {
+  		return value, nil
+  	}
+  	zr, err := gzip.NewReader(strings.NewReader(value))
+  	if err != nil {
+  		return value, nil // Does not return error, the value could be not compressed
+  	}
+  	defer zr.Close()
+  	var unCompressedValue bytes.Buffer
+  	_, err = io.Copy(&unCompressedValue, zr)
+  	if err != nil {
+  		return value, nil
+  	}
+  	return unCompressedValue.String(), nil
+  }
+
+  c := mc.NewMCwithConfig("localhost:11211", "username", "password", config)
+  defer c.Quit()
+
+  exp := 3600 // 2 hours
+  cas, err = c.Set("foo", "bar", flags, exp, cas)
+  if err != nil {
+  	...
+  }
+
+  val, flags, cas, err = c.Get("foo")
+  if err != nil {
+  	...
+  }
+
+  err = c.Del("foo")
+  if err != nil {
+  	...
+  }
 }
 ```
 

--- a/client.go
+++ b/client.go
@@ -157,8 +157,8 @@ func (c *Client) getCAS(key string, ocas uint64) (val string, flags uint32, cas 
 	}
 
 	err = c.perform(m)
-	if c.config.Compression.decompress != nil && err == nil {
-		m.val, err = c.config.Compression.decompress(m.val)
+	if c.config.Compression.Decompress != nil && err == nil {
+		m.val, err = c.config.Compression.Decompress(m.val)
 	}
 	return m.val, flags, m.CAS, err
 }
@@ -234,8 +234,8 @@ func (c *Client) setGeneric(op opCode, key, val string, ocas uint64, flags, exp 
 		key:     key,
 		val:     val,
 	}
-	if c.config.Compression.compress != nil {
-		m.val, err = c.config.Compression.compress(m.val)
+	if c.config.Compression.Compress != nil {
+		m.val, err = c.config.Compression.Compress(m.val)
 		if err != nil {
 			return m.CAS, err
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -1619,8 +1619,47 @@ func TestGetServer(t *testing.T) {
 	assertEqualf(t, mcAddr, s.address, "address of incorrect server returned")
 }
 
-func TestMCCompression(t *testing.T) {
-	c := testInitCompress(t)
+func TestMCZlibCompression(t *testing.T) {
+	c := testZlibCompress(t)
+
+	const (
+		Key1 = "foo"
+		Val1 = "bar"
+		Val2 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc fermentum arcu id libero maximus mollis. Nulla id lorem efficitur, maximus risus vitae, iaculis libero. Mauris non vehicula tortor. Etiam fringilla dictum elit. Donec dui justo, semper et nisl vitae, vestibulum tempus enim. Aenean id lacinia diam. Integer viverra viverra augue, vitae feugiat mauris posuere at. Praesent luctus, urna eu sollicitudin ultrices, enim tortor sagittis nunc, eget ultricies nisi nibh in neque. Integer eget commodo ipsum, non congue purus. Nullam erat felis, dictum vel ligula ut, maximus aliquet justo. Nunc volutpat magna vitae arcu consectetur, vitae molestie odio efficitur."
+		Val3 = "Praesent vel pretium elit. Donec volutpat placerat dolor eu tempus. Vivamus suscipit maximus tortor quis interdum. Cras venenatis consectetur pellentesque. Pellentesque gravida ut mi sit amet bibendum. Phasellus bibendum ex sit amet dolor condimentum mattis. Cras nunc diam, ornare quis velit sed, ullamcorper viverra erat. Nunc placerat tempus porttitor. Suspendisse vestibulum nisl a mauris mollis rhoncus. Morbi consequat felis sit amet magna iaculis scelerisque."
+	)
+
+	// fmt.Printf("test init: %v", c)
+	val, flags, cs, err := c.Get(Key1)
+	if err != ErrNotFound {
+		t.Errorf("val: %v, flags: %v, cas: %v", val, flags, cs)
+		t.Fatalf("expected missing key: %v", err)
+	}
+
+	// unconditional SET
+	_, err = c.Set(Key1, Val1, 0, 0, 0)
+	assertEqualf(t, mcNil, err, "unexpected error: %v", err)
+	cas, err := c.Set(Key1, Val1, 0, 0, 0)
+	assertEqualf(t, mcNil, err, "unexpected error: %v", err)
+
+	// make sure CAS works
+	_, err = c.Set(Key1, Val2, 0, 0, cas+1)
+	assertEqualf(t, ErrKeyExists, err, "expected CAS mismatch: %v", err)
+
+	// check SET actually set the correct value...
+	v, _, cas2, err := c.Get(Key1)
+	assertEqualf(t, mcNil, err, "unexpected error: %v", err)
+	assertEqualf(t, Val1, v, "wrong value: %s", v)
+	assertEqualf(t, cas, cas2, "CAS shouldn't have changed: %d, %d", cas, cas2)
+
+	// use correct CAS...
+	cas2, err = c.Set(Key1, Val3, 0, 0, cas)
+	assertEqualf(t, mcNil, err, "unexpected error: %v", err)
+	assertNotEqualf(t, cas, cas2, "CAS should not be the same")
+}
+
+func TestMCGzipCompression(t *testing.T) {
+	c := testGzipCompress(t)
 
 	const (
 		Key1 = "foo"

--- a/config.go
+++ b/config.go
@@ -23,8 +23,8 @@ type Config struct {
 	TcpKeepAlivePeriod time.Duration
 	TcpNoDelay         bool
 	Compression        struct {
-		decompress func(value string) (string, error)
-		compress   func(value string) (string, error)
+		Decompress func(value string) (string, error)
+		Compress   func(value string) (string, error)
 	}
 }
 
@@ -44,8 +44,8 @@ The default values currently are:
 		TcpKeepAlivePeriod: 60 * time.Second,
 		TcpNoDelay:         true,
 		Compression        struct {
-			decompress  nil
-			compress 		nil
+			Decompress  nil
+			Compress 		nil
 		}
 	}
 */
@@ -62,8 +62,8 @@ func DefaultConfig() *Config {
 		TcpKeepAlivePeriod: 60 * time.Second,
 		TcpNoDelay:         true,
 		Compression: struct {
-			decompress func(value string) (string, error)
-			compress   func(value string) (string, error)
-		}{decompress: nil, compress: nil},
+			Decompress func(value string) (string, error)
+			Compress   func(value string) (string, error)
+		}{Decompress: nil, Compress: nil},
 	}
 }


### PR DESCRIPTION
The idea was just to fix the Readme.md adding gzip compression example but I noticed that the decompress and compress methods were private and then I changed their names to make Decompress and Compress public.

I Also added a gzip test

After this PR I think that is safe to upgrade the package at https://pkg.go.dev/github.com/memcachier/mc/v3
